### PR TITLE
Correction de syntaxe de la phase after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ cache:
   directories:
     - $HOME/.m2
 
-after-success:
+after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Corrige "after-success" en "after_success"