### PR TITLE
Utilise un nom d'origine différent pour push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>fr.uga.fran</groupId>
   <artifactId>jelly</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.2</version>
+  <version>0.2-SNAPSHOT</version>
   <name>jelly</name>
   <url>http://maven.apache.org</url>
 

--- a/scripts/push_pom.sh
+++ b/scripts/push_pom.sh
@@ -9,8 +9,8 @@ git checkout -b master
 
 # Commit pom.xml
 git add pom.xml
-git commit -m "Prepare next release"
+git commit -m "Prepare la prochaine release (version SNAPSHOT)"
 
 # Push pom.xml
-git remote add origin https://${GITHUB_TOKEN}@github.com/madoci/jelly.git
-git push --quiet --set-upstream origin master
+git remote add origin-travis https://${GITHUB_TOKEN}@github.com/madoci/jelly.git
+git push --quiet --set-upstream origin-travis master


### PR DESCRIPTION
L'URL origin est déjà utilisée lors des build de Travis CI.